### PR TITLE
Define SQLAlchemy ORM models and enums

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,17 @@
+from src.database.database import Base
+from src.models.enums import UnitEnum
+from src.models.exercise import Exercise
+from src.models.exercise_session import ExerciseSession
+from src.models.session import Session
+from src.models.set import Set
+from src.models.template import Template
+
+__all__ = [
+    "Base",
+    "Exercise",
+    "Session",
+    "Template",
+    "ExerciseSession",
+    "Set",
+    "UnitEnum",
+]

--- a/src/models/enums.py
+++ b/src/models/enums.py
@@ -1,0 +1,5 @@
+import enum
+
+class UnitEnum(str, enum.Enum):
+    kg = "kg"
+    stacks = "stacks"

--- a/src/models/exercise.py
+++ b/src/models/exercise.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
+
+from src.database.database import Base
+
+class Exercise(Base):
+    __tablename__ = "exercises"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name_en = Column(String, nullable=False, index=True)
+    name_pt = Column(String, nullable=False, index=True)
+    image_url = Column(String, nullable=True)
+    category = Column(String, nullable=False, index=True)
+    subcategory = Column(String, nullable=True, index=True)
+    equipment = Column(String, nullable=True)
+
+    exercise_sessions = relationship("ExerciseSession", back_populates="exercise")

--- a/src/models/exercise_session.py
+++ b/src/models/exercise_session.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, ForeignKey, Integer
+from sqlalchemy.orm import relationship
+
+from src.database.database import Base
+
+class ExerciseSession(Base):
+    __tablename__ = "exercise_sessions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    exercise_id = Column(Integer, ForeignKey("exercises.id"), nullable=False)
+    session_id = Column(Integer, ForeignKey("sessions.id"), nullable=True)
+    template_id = Column(Integer, ForeignKey("templates.id"), nullable=True)
+
+    exercise = relationship("Exercise", back_populates="exercise_sessions")
+    session = relationship("Session", back_populates="exercise_sessions")
+    template = relationship("Template", back_populates="exercise_sessions")
+    sets = relationship(
+        "Set", back_populates="exercise_session", cascade="all, delete-orphan"
+    )

--- a/src/models/session.py
+++ b/src/models/session.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, DateTime, Integer, func
+from sqlalchemy.orm import relationship
+
+from src.database.database import Base
+
+class Session(Base):
+    __tablename__ = "sessions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    date = Column(DateTime, default=func.now(), index=True)
+
+    exercise_sessions = relationship("ExerciseSession", back_populates="session")

--- a/src/models/set.py
+++ b/src/models/set.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Enum, Float, ForeignKey, Integer
+from sqlalchemy.orm import relationship
+
+from src.database.database import Base
+from src.models.enums import UnitEnum
+
+class Set(Base):
+    __tablename__ = "sets"
+
+    id = Column(Integer, primary_key=True, index=True)
+    weight = Column(Float, nullable=False)
+    reps = Column(Integer, nullable=False)
+    unit = Column(Enum(UnitEnum), nullable=False)
+    exercise_session_id = Column(Integer, ForeignKey("exercise_sessions.id"), nullable=False)
+
+    exercise_session = relationship("ExerciseSession", back_populates="sets")

--- a/src/models/template.py
+++ b/src/models/template.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
+
+from src.database.database import Base
+
+class Template(Base):
+    __tablename__ = "templates"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+
+    exercise_sessions = relationship("ExerciseSession", back_populates="template")


### PR DESCRIPTION
✅ Define SQLAlchemy ORM models and enums (Step 2 complete)

✨ What’s Changed  
- Added SQLAlchemy models for: `Exercise`, `Session`, `Template`, `ExerciseSession`, `Set`
- Created `UnitEnum` enum for weight units (`kg`, `stacks`)
- Defined relationships between exercises, sets, sessions, and templates
- Updated `models/__init__.py` to expose all models and `Base`

✅ Why  
- This establishes the full database schema needed for the Progressive Overload Tracker. These models are the foundation for future steps like migrations, schemas, and services.

🧪 Testing  
- Verified model imports with `python -c` one-liner ✅  
- Ran a dummy SQLite script to create and commit an `Exercise` instance successfully ✅  
