### PR TITLE
fix: correct enum cast in exercise search function

### DIFF
--- a/src/services/exercise_service.py
+++ b/src/services/exercise_service.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 from sqlalchemy.orm import Session
 from fastapi import HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import select, String
 
 from src.models.exercise import Exercise
 from src.schemas.exercise import ExerciseCreate, ExerciseUpdate
@@ -38,7 +38,7 @@ def search_exercises(query: str, db: Session) -> List[Exercise]:
     result = db.execute(
         select(Exercise).where(
             (Exercise.name.ilike(search))
-            | (Exercise.category.cast(db.bind.dialect.name).ilike(search))
+            | (Exercise.category.cast(String).ilike(search))
             | (Exercise.subcategory.ilike(search))
         )
     )


### PR DESCRIPTION
## Fix: Correct Enum Cast in Exercise Search Function

  ### Summary
  Fixes a bug in the `search_exercises` service function where enum category field was being cast incorrectly, causing search to fail with a 500 error.

  ### Changes
  - Cast `category` enum field to `String` type instead of using dialect name
  - Import `String` from SQLAlchemy

  ### Issue
  The search function was trying to cast the enum using `db.bind.dialect.name` (which returns a string like "postgresql"), but `.cast()` expects a SQLAlchemy type object.

  ### Testing
  - ✅ Search by exercise name works correctly
  - ✅ Search by category works correctly
  - ✅ Search by subcategory works correctly