### PR TITLE
fix: remove invalid sets relationship from Session model

### DIFF
--- a/src/models/session.py
+++ b/src/models/session.py
@@ -20,8 +20,3 @@ class Session(Base):
         back_populates="session",
         cascade="all, delete-orphan"
     )
-    sets = relationship(
-        "Set",
-        back_populates="session",
-        cascade="all, delete-orphan"
-    )


### PR DESCRIPTION
## Fix: Remove Invalid Sets Relationship from Session Model

  ### Summary
  Fixes a SQLAlchemy relationship configuration error in the Session model that was causing all database queries to fail with "NoForeignKeysError".

  ### Changes
  - Remove invalid `sets` relationship from Session model
  - Set table only has foreign key to `exercise_sessions`, not `sessions`

  ### Issue
  The Session model attempted to define a direct relationship to the Set table, but no foreign key exists between these tables. Sets are linked to Sessions indirectly through
  ExerciseSession.

  ### Relationship Structure
  Session -> ExerciseSession -> Set

  ### Testing
  - ✅ All API endpoints now work without SQLAlchemy errors
  - ✅ Database queries execute successfully
