### PR TITLE
Feature/sessions templates routers

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from src.routers import exercises, users
+from src.routers import exercises, users, sessions, templates
 
 app = FastAPI(
     title="Progressive Overload Tracker API",
@@ -10,6 +10,8 @@ app = FastAPI(
 # Include routers
 app.include_router(exercises.router)
 app.include_router(users.router)
+app.include_router(sessions.router)
+app.include_router(templates.router)
 
 @app.get("/")
 async def root():

--- a/src/routers/sessions.py
+++ b/src/routers/sessions.py
@@ -1,0 +1,88 @@
+from typing import List, Optional
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.orm import Session
+
+from src.database.database import get_db
+from src.schemas.session import SessionCreate, SessionUpdate, SessionWithDetails
+from src.services import session_service
+
+router = APIRouter(prefix="/sessions", tags=["sessions"])
+
+
+@router.get("/", response_model=List[SessionWithDetails])
+def list_sessions(
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(100, ge=1, le=1000, description="Maximum number of records to return"),
+    db: Session = Depends(get_db),
+):
+    """
+    Retrieve a list of workout sessions with their exercises and sets.
+
+    - **skip**: Number of records to skip (for pagination)
+    - **limit**: Maximum number of records to return
+    """
+    return session_service.get_sessions(db, skip=skip, limit=limit)
+
+
+@router.get("/{session_id}", response_model=SessionWithDetails)
+def get_session(
+    session_id: int,
+    db: Session = Depends(get_db),
+):
+    """
+    Retrieve a specific workout session by ID, including exercises and sets.
+
+    - **session_id**: The ID of the session to retrieve
+    """
+    return session_service.get_session(session_id, db)
+
+
+@router.post("/", response_model=SessionWithDetails, status_code=status.HTTP_201_CREATED)
+def create_session(
+    session: SessionCreate,
+    db: Session = Depends(get_db),
+):
+    """
+    Create a new workout session with nested exercises and sets.
+
+    - **user_id**: ID of the user who owns this session
+    - **date**: Optional session date and time (defaults to now)
+    - **exercise_sessions**: List of exercises in this session, each with:
+      - **exercise_id**: ID of the exercise
+      - **sets**: List of sets for this exercise, each with:
+        - **weight**: Weight used
+        - **reps**: Number of repetitions
+        - **unit**: Unit of measurement (kg or stacks)
+    """
+    return session_service.create_session(session, db)
+
+
+@router.put("/{session_id}", response_model=SessionWithDetails)
+def update_session(
+    session_id: int,
+    session: SessionUpdate,
+    db: Session = Depends(get_db),
+):
+    """
+    Update an existing workout session.
+
+    - **session_id**: The ID of the session to update
+    - All fields are optional; only provided fields will be updated
+    - Note: This endpoint updates session metadata only, not nested exercises/sets
+    """
+    return session_service.update_session(session_id, session, db)
+
+
+@router.delete("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_session(
+    session_id: int,
+    db: Session = Depends(get_db),
+):
+    """
+    Delete a workout session.
+
+    - **session_id**: The ID of the session to delete
+    - This will cascade delete all associated exercise_sessions and sets
+    """
+    session_service.delete_session(session_id, db)
+    return None

--- a/src/routers/templates.py
+++ b/src/routers/templates.py
@@ -1,0 +1,83 @@
+from typing import List
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.orm import Session
+
+from src.database.database import get_db
+from src.schemas.template import TemplateCreate, TemplateUpdate, TemplateWithExerciseSessions
+from src.services import template_service
+
+router = APIRouter(prefix="/templates", tags=["templates"])
+
+
+@router.get("/", response_model=List[TemplateWithExerciseSessions])
+def list_templates(
+    skip: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(100, ge=1, le=1000, description="Maximum number of records to return"),
+    db: Session = Depends(get_db),
+):
+    """
+    Retrieve a list of workout templates with their exercises.
+
+    - **skip**: Number of records to skip (for pagination)
+    - **limit**: Maximum number of records to return
+    """
+    return template_service.get_templates(db, skip=skip, limit=limit)
+
+
+@router.get("/{template_id}", response_model=TemplateWithExerciseSessions)
+def get_template(
+    template_id: int,
+    db: Session = Depends(get_db),
+):
+    """
+    Retrieve a specific workout template by ID, including its exercises.
+
+    - **template_id**: The ID of the template to retrieve
+    """
+    return template_service.get_template(template_id, db)
+
+
+@router.post("/", response_model=TemplateWithExerciseSessions, status_code=status.HTTP_201_CREATED)
+def create_template(
+    template: TemplateCreate,
+    db: Session = Depends(get_db),
+):
+    """
+    Create a new workout template with associated exercises.
+
+    - **name**: Name of the template
+    - **user_id**: ID of the user who owns this template
+    - **exercise_ids**: List of exercise IDs to include in this template
+    """
+    return template_service.create_template(template, db)
+
+
+@router.put("/{template_id}", response_model=TemplateWithExerciseSessions)
+def update_template(
+    template_id: int,
+    template: TemplateUpdate,
+    db: Session = Depends(get_db),
+):
+    """
+    Update an existing workout template.
+
+    - **template_id**: The ID of the template to update
+    - All fields are optional; only provided fields will be updated
+    - Note: This endpoint updates template metadata only, not associated exercises
+    """
+    return template_service.update_template(template_id, template, db)
+
+
+@router.delete("/{template_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_template(
+    template_id: int,
+    db: Session = Depends(get_db),
+):
+    """
+    Delete a workout template.
+
+    - **template_id**: The ID of the template to delete
+    - This will cascade delete all associated exercise_sessions
+    """
+    template_service.delete_template(template_id, db)
+    return None


### PR DESCRIPTION
## Summary
  - Add complete CRUD endpoints for workout sessions with nested exercises and sets
  - Add complete CRUD endpoints for workout templates with associated exercises
  - Update main.py to include new routers

  ## Changes
  - **src/routers/sessions.py**: New router with 5 endpoints
    - GET /sessions - list with pagination
    - GET /sessions/{id} - get with full details
    - POST /sessions - create with nested exercises/sets
    - PUT /sessions/{id} - update metadata
    - DELETE /sessions/{id} - delete with cascade
    
  - **src/routers/templates.py**: New router with 5 endpoints
    - GET /templates - list with pagination
    - GET /templates/{id} - get with exercises
    - POST /templates - create with exercise IDs
    - PUT /templates/{id} - update metadata
    - DELETE /templates/{id} - delete with cascade

  - **src/main.py**: Include sessions and templates routers

  ## Test plan
  - [x] All endpoints registered in OpenAPI spec
  - [x] Server starts successfully with routers loaded
  - [x] Schemas properly serialize with forward references
