### PR TITLE
feat: add foreign key validation in session and template services

### DIFF
--- a/tests/test_api/test_sessions.py
+++ b/tests/test_api/test_sessions.py
@@ -92,14 +92,12 @@ class TestSessionsAPI:
         data = response.json()
         assert len(data["exercise_sessions"]) == 2
 
-    @pytest.mark.skip(reason="FK validation not yet implemented")
     def test_create_session_invalid_user(self, client: TestClient):
         """Test creating session with non-existent user."""
         session_data = {"user_id": 99999, "exercise_sessions": []}
         response = client.post("/sessions/", json=session_data)
         assert response.status_code == 404
 
-    @pytest.mark.skip(reason="FK validation not yet implemented")
     def test_create_session_invalid_exercise(self, client: TestClient):
         """Test creating session with non-existent exercise."""
         # Create user

--- a/tests/test_api/test_templates.py
+++ b/tests/test_api/test_templates.py
@@ -58,7 +58,6 @@ class TestTemplatesAPI:
         assert data["exercise_sessions"][0]["exercise"]["id"] == exercise1["id"]
         assert data["exercise_sessions"][1]["exercise"]["id"] == exercise2["id"]
 
-    @pytest.mark.skip(reason="FK validation not yet implemented")
     def test_create_template_invalid_user(self, client: TestClient):
         """Test creating template with non-existent user."""
         template_data = {
@@ -69,7 +68,6 @@ class TestTemplatesAPI:
         response = client.post("/templates/", json=template_data)
         assert response.status_code == 404
 
-    @pytest.mark.skip(reason="FK validation not yet implemented")
     def test_create_template_invalid_exercise(self, client: TestClient):
         """Test creating template with non-existent exercise."""
         # Create user


### PR DESCRIPTION
## Summary

  This PR adds foreign key validation to session and template creation endpoints. Previously, the API would accept invalid `user_id` or `exercise_id` values and either create
  orphaned records or return generic database integrity errors. Now it validates these references upfront and returns clear 404 errors.

  ### Changes Made

  - Added user existence validation in `session_service.create_session()`
  - Added exercise existence validation for all exercises in `session_service.create_session()`
  - Added user existence validation in `template_service.create_template()`
  - Added exercise existence validation for all exercises in `template_service.create_template()`
  - Returns `404 NOT FOUND` with descriptive error messages when foreign keys don't exist
  - Updated imports to include `User` and `Exercise` models

  ### Test Results

  **Before:** 57 passing, 11 skipped
  **After:** 61 passing, 7 skipped

  Unskipped and now passing:
  - `test_create_session_invalid_user` - Returns 404 when user doesn't exist
  - `test_create_session_invalid_exercise` - Returns 404 when exercise doesn't exist
  - `test_create_template_invalid_user` - Returns 404 when user doesn't exist
  - `test_create_template_invalid_exercise` - Returns 404 when exercise doesn't exist

  ### Error Response Examples

  **Invalid User:**
  ```bash
  POST /sessions/
  {"user_id": 99999, "exercise_sessions": []}

  Response: 404 NOT FOUND
  {
    "detail": "User with id 99999 not found"
  }
```

  **Invalid Exercise:**
  ```bash
POST /sessions/
  {
    "user_id": 1,
    "exercise_sessions": [{"exercise_id": 99999, "sets": []}]
  }

  Response: 404 NOT FOUND
  {
    "detail": "Exercise with id 99999 not found"
  }
```
  Benefits

  ✅ Better UX: Clear, actionable error messages instead of cryptic database errors
  ✅ Fail Fast: Validates all foreign keys before any database writes
  ✅ Consistency: Same validation approach for both sessions and templates